### PR TITLE
Reallocating memory for a larger name

### DIFF
--- a/books/en-US/book.md
+++ b/books/en-US/book.md
@@ -4255,7 +4255,10 @@ int main(void) {
     print_student(c);
 
     // Modify dynamically allocated memory
-    strcpy(b->name, "Bobby");
+    char new_name[] = "Bobby";
+    b->name = realloc(b->name, strlen(new_name) + 1);
+    strcpy(b->name, new_name);
+
     b->gpa = 3.6f;
     printf("\nAfter update:\n");
     print_student(b);

--- a/books/en-US/book.md
+++ b/books/en-US/book.md
@@ -5363,17 +5363,29 @@ Rectangle 3.00x4.00
 
 This pairing of `enum` + `union` is a common pattern in real-world systems, known as a **tagged union**.
 
-#### Scoped Enums in Modern C (C23)
+#### Underlying types in Modern C (C23)
 
-C23 introduces a cleaner way to scope enum names:
+In C23, the underlying type of an enumeration refers to the integer type used to
+represent the enum values in memory. Prior to C23, this type was
+implementation-defined and could be any integer type capable of holding all
+enumerator values, typically `int`. With C23, programmers can now explicitly
+specify the underlying type using the syntax `enum name : type`, allowing precise
+control over storage size and signedness (e.g., `enum color : unsigned char`).
+
+This enables more efficient memory usage and predictable behavior across
+platforms, especially in embedded systems or when interfacing with hardware.
+Enumerations with a fixed underlying type are compatible with that type and must
+accommodate all enumerator values; otherwise, a compile-time error occurs.
+
+Example:
 
 ```c
-enum class Mode { READ, WRITE, APPEND };
+enum color : unsigned char {
+    RED,
+    GREEN,
+    BLUE
+};
 ```
-
-This avoids name collisions and allows better type checking —
-similar to `enum class` in C++.
-(Some compilers may not support this yet, but it's worth knowing.)
 
 #### Why It Matters
 


### PR DESCRIPTION
Hi! Just noticed, while reading the book, that "Bobby" has more bytes than the original allocated "Bob". Running the code works, but can lead to a buffer overflow. Running the original code with Valgrind:

```
❯ valgrind --tool=memcheck --leak-check=yes -q ./struct
=== Manual Memory Management Demo ===
Name: Alice      | Age: 20 | GPA: 3.80
Name: Bob        | Age: 22 | GPA: 3.40
Name: Carol      | Age: 19 | GPA: 3.90
==205819== Invalid write of size 2
==205819==    at 0x4001406: main (in /home/taq/code/c/struct)
==205819==  Address 0x4ace574 is 0 bytes after a block of size 4 alloc'd
==205819==    at 0x485280F: malloc (vg_replace_malloc.c:447)
==205819==    by 0x4001266: create_student (in /home/taq/code/c/struct)
==205819==    by 0x40013AE: main (in /home/taq/code/c/struct)
==205819== 

After update:
==205819== Invalid read of size 1
==205819==    at 0x485C424: strlen (vg_replace_strmem.c:506)
==205819==    by 0x48F797F: __printf_buffer (vfprintf-process-arg.c:443)
==205819==    by 0x48F8787: __vfprintf_internal (vfprintf-internal.c:1543)
==205819==    by 0x48EC1F2: printf (printf.c:33)
==205819==    by 0x4001322: print_student (in /home/taq/code/c/struct)
==205819==    by 0x4001437: main (in /home/taq/code/c/struct)
==205819==  Address 0x4ace574 is 0 bytes after a block of size 4 alloc'd
==205819==    at 0x485280F: malloc (vg_replace_malloc.c:447)
==205819==    by 0x4001266: create_student (in /home/taq/code/c/struct)
==205819==    by 0x40013AE: main (in /home/taq/code/c/struct)
==205819== 
==205819== Invalid read of size 1
==205819==    at 0x4860200: memmove (vg_replace_strmem.c:1415)
==205819==    by 0x48ECE27: memcpy (string_fortified.h:29)
==205819==    by 0x48ECE27: __printf_buffer_write (Xprintf_buffer_write.c:39)
==205819==    by 0x48F76FD: __printf_buffer (vfprintf-process-arg.c:471)
==205819==    by 0x48F8787: __vfprintf_internal (vfprintf-internal.c:1543)
==205819==    by 0x48EC1F2: printf (printf.c:33)
==205819==    by 0x4001322: print_student (in /home/taq/code/c/struct)
==205819==    by 0x4001437: main (in /home/taq/code/c/struct)
==205819==  Address 0x4ace574 is 0 bytes after a block of size 4 alloc'd
==205819==    at 0x485280F: malloc (vg_replace_malloc.c:447)
==205819==    by 0x4001266: create_student (in /home/taq/code/c/struct)
==205819==    by 0x40013AE: main (in /home/taq/code/c/struct)
==205819== 
Name: Bobby      | Age: 22 | GPA: 3.60

All memory released.

```

Also, seems there's a mistake on enums and C23. I changed to reflect what is supported there.